### PR TITLE
fix(ai-services): remove 24-hour automatic memory reset

### DIFF
--- a/backEnd/ai-services/src/__tests__/models/shortTermMemory.model.test.ts
+++ b/backEnd/ai-services/src/__tests__/models/shortTermMemory.model.test.ts
@@ -33,32 +33,6 @@ describe('ShortTermMemory', () => {
       const session2 = stm.getSession('user1_chat1')
       expect(session1).toBe(session2)
     })
-
-    it('should create a new session when the previous one is expired', () => {
-      const stm = ShortTermMemory.getInstance()
-      const session1 = stm.getSession('user1_chat1')
-
-      // Force expiration by setting expiresAt to the past
-      const sessions = (stm as any).sessions as Map<string, any>
-      sessions.get('user1_chat1').expiresAt = Date.now() - 1
-
-      const session2 = stm.getSession('user1_chat1')
-      expect(session2).not.toBe(session1)
-    })
-
-    it('should extend TTL when accessing an active session', () => {
-      const stm = ShortTermMemory.getInstance()
-      stm.getSession('user1_chat1')
-
-      const sessions = (stm as any).sessions as Map<string, any>
-      const originalExpiry = sessions.get('user1_chat1').expiresAt
-
-      // Access again and verify TTL is extended
-      stm.getSession('user1_chat1')
-      const newExpiry = sessions.get('user1_chat1').expiresAt
-
-      expect(newExpiry).toBeGreaterThanOrEqual(originalExpiry)
-    })
   })
 
   describe('deleteSession', () => {
@@ -74,22 +48,6 @@ describe('ShortTermMemory', () => {
     it('should be a no-op when session does not exist', () => {
       const stm = ShortTermMemory.getInstance()
       expect(() => stm.deleteSession('nonexistent')).not.toThrow()
-    })
-  })
-
-  describe('deleteOldSessions', () => {
-    it('should remove expired sessions', () => {
-      const stm = ShortTermMemory.getInstance()
-      stm.getSession('user1_chat1')
-      stm.getSession('user1_chat2')
-
-      const sessions = (stm as any).sessions as Map<string, any>
-      sessions.get('user1_chat1').expiresAt = Date.now() - 1 // expired
-
-      stm.deleteOldSessions()
-
-      expect(sessions.has('user1_chat1')).toBe(false)
-      expect(sessions.has('user1_chat2')).toBe(true)
     })
   })
 

--- a/backEnd/ai-services/src/models/shortTermMemory.model.ts
+++ b/backEnd/ai-services/src/models/shortTermMemory.model.ts
@@ -1,11 +1,8 @@
 import { OpenAIConversationsSession } from "@openai/agents"
 
 type SessionEntry = {
-    session: OpenAIConversationsSession,
-    expiresAt: number
+    session: OpenAIConversationsSession
 }
-
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000; //24 hours
 
 class ShortTermMemory {
     private sessions = new Map<string, SessionEntry>()
@@ -18,23 +15,16 @@ class ShortTermMemory {
 
         return ShortTermMemory.instance
     }
-    
-    getSession(conversationId: string): OpenAIConversationsSession {
-        const now = Date.now()
 
+    getSession(conversationId: string): OpenAIConversationsSession {
         const currentSession = this.sessions.get(conversationId)
 
-        if(currentSession && currentSession.expiresAt > now) {
-            currentSession.expiresAt = now + SESSION_TTL_MS
+        if(currentSession) {
             return currentSession.session
         }
 
         const newSession = new OpenAIConversationsSession()
-
-        this.sessions.set(conversationId, {
-            session: newSession,
-            expiresAt: now + SESSION_TTL_MS
-        })
+        this.sessions.set(conversationId, { session: newSession })
 
         return newSession
     }
@@ -43,16 +33,6 @@ class ShortTermMemory {
         if(this.sessions.has(conversationId)) {
             this.sessions.delete(conversationId)
         }
-    }
-
-    deleteOldSessions() {
-        const now = Date.now()
-
-        this.sessions.forEach((entry, conversationId) => {
-            if(entry.expiresAt <= now) {
-                this.sessions.delete(conversationId)
-            }
-        })
     }
 
     deleteUserSessions(uid: string) {


### PR DESCRIPTION
Removes the 24-hour TTL from ShortTermMemory so sessions persist until a token-based reset or explicit deletion. The deleteOldSessions method and all TTL-related test cases are also removed.

Closes #186

Generated with [Claude Code](https://claude.ai/code)