### PR TITLE
fix: isolate title_generator from conversation STM session

### DIFF
--- a/backEnd/ai-services/src/services/elber.service.ts
+++ b/backEnd/ai-services/src/services/elber.service.ts
@@ -111,8 +111,6 @@ const generateChatTitle = async (uid: string, request: ElberRequest, emitMessage
             - Último mensaje del usuario: "${text}"
         `
     
-        const conversationId = `${uid}_${chatId.toString()}`
-        const session = ShortTermMemory.getInstance().getSession(conversationId)
         const title_agent = getAgents('title_generator')
 
         if(!title_agent) {
@@ -120,9 +118,8 @@ const generateChatTitle = async (uid: string, request: ElberRequest, emitMessage
         }
 
         const result = await run(title_agent, context, {
-            session,
             maxTurns: 3
-        })           
+        })
         
         if(result.finalOutput && result.finalOutput.changeTitle) {
             updateTitle(uid, chatId, result.finalOutput.chatTitle)


### PR DESCRIPTION
Fixes #188

The `generateChatTitle` function was passing the main conversation's `OpenAIConversationsSession` to the `title_generator` agent. This caused the agent to receive the full chat history as unnecessary context, and its exchange was written back into the session, polluting the conversation history visible to the chat agent on subsequent turns.

Removing the session parameter makes title generation stateless and prevents session bloat that contributed to latency spikes.

Generated with [Claude Code](https://claude.ai/code)