### PR TITLE
refactor: extract search business logic to search.service.ts

### DIFF
--- a/backEnd/ai-services/src/__tests__/services/search.service.test.ts
+++ b/backEnd/ai-services/src/__tests__/services/search.service.test.ts
@@ -1,0 +1,73 @@
+import axios from 'axios'
+import { searchWeb } from '../../services/search.service'
+
+jest.mock('axios')
+
+jest.mock('../../config/index.config', () => ({
+    serper: { searchURL: 'https://google.serper.dev/search', secret: 'test-serper-key' },
+}))
+
+describe('searchWeb', () => {
+    const mockAxiosRequest = axios.request as jest.Mock
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should return organic results when API responds with them', async () => {
+        const organicResults = [{ title: 'Result 1', link: 'https://example.com' }]
+        mockAxiosRequest.mockResolvedValue({ data: { organic: organicResults } })
+
+        const result = await searchWeb('¿Qué pasó hoy?', 'America/New_York')
+        expect(result).toEqual(organicResults)
+    })
+
+    it('should return fallback message when no organic results', async () => {
+        mockAxiosRequest.mockResolvedValue({ data: {} })
+
+        const result = await searchWeb('some query', 'America/New_York')
+        expect(result).toBe('No tengo la información. Sigo aprendiendo')
+    })
+
+    it('should map Mexico City timezone to "mx" country code', async () => {
+        mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
+
+        await searchWeb('noticias', 'America/Mexico_City')
+
+        const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
+        expect(callData.gl).toBe('mx')
+    })
+
+    it('should default to "us" for unknown timezones', async () => {
+        mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
+
+        await searchWeb('news', 'Europe/London')
+
+        const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
+        expect(callData.gl).toBe('us')
+    })
+
+    it('should append timezone info to query for time-related searches', async () => {
+        mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
+
+        await searchWeb('¿cuándo es el partido?', 'America/Mexico_City')
+
+        const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
+        expect(callData.q).toContain('Mexico City')
+    })
+
+    it('should use "es" as the language for all requests', async () => {
+        mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
+
+        await searchWeb('test', 'America/New_York')
+
+        const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
+        expect(callData.hl).toBe('es')
+    })
+
+    it('should throw when axios throws', async () => {
+        mockAxiosRequest.mockRejectedValue(new Error('Network error'))
+
+        await expect(searchWeb('some query', 'America/New_York')).rejects.toThrow('Network error')
+    })
+})

--- a/backEnd/ai-services/src/__tests__/tools/search.tools.test.ts
+++ b/backEnd/ai-services/src/__tests__/tools/search.tools.test.ts
@@ -1,11 +1,9 @@
-import axios from 'axios'
 import { webSearch as webSearchTool } from '../../agents/tools/search.tools'
+import { searchWeb } from '../../services/search.service'
 
 // The mock makes `tool()` return the config object directly, which has `execute`.
 // Cast to any since FunctionTool's TS types don't expose execute publicly.
 const webSearch = webSearchTool as any
-
-jest.mock('axios')
 
 jest.mock('@openai/agents', () => ({
   __esModule: true,
@@ -13,80 +11,40 @@ jest.mock('@openai/agents', () => ({
   run: jest.fn(),
 }))
 
-jest.mock('../../config/index.config', () => ({
-  serper: { searchURL: 'https://google.serper.dev/search', secret: 'test-serper-key' },
-}))
+jest.mock('../../services/search.service')
+
+const mockSearchWeb = searchWeb as jest.Mock
 
 describe('webSearch tool', () => {
-  const mockAxiosRequest = axios.request as jest.Mock
-
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('should return organic results when API responds with them', async () => {
+  it('should call searchWeb with query and timezone from context', async () => {
     const organicResults = [{ title: 'Result 1', link: 'https://example.com' }]
-    mockAxiosRequest.mockResolvedValue({ data: { organic: organicResults } })
+    mockSearchWeb.mockResolvedValue(organicResults)
 
-    const result = await webSearch.execute({ query: '¿Qué pasó hoy?' })
-    expect(result).toEqual(organicResults)
-  })
-
-  it('should return fallback message when no organic results', async () => {
-    mockAxiosRequest.mockResolvedValue({ data: {} })
-
-    const result = await webSearch.execute({ query: 'some query' })
-    expect(result).toBe('No tengo la información. Sigo aprendiendo')
-  })
-
-  it('should return error message when axios throws', async () => {
-    mockAxiosRequest.mockRejectedValue(new Error('Network error'))
-
-    const result = await webSearch.execute({ query: 'some query' })
-    expect(result).toBe('Hubo un error al buscar la información')
-  })
-
-  it('should map Mexico City timezone to "mx" country code', async () => {
-    mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
-
-    await webSearch.execute(
+    const result = await webSearch.execute(
       { query: 'noticias' },
       { context: { userId: 'u1', timeZone: 'America/Mexico_City' } } as any
     )
 
-    const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
-    expect(callData.gl).toBe('mx')
+    expect(mockSearchWeb).toHaveBeenCalledWith('noticias', 'America/Mexico_City')
+    expect(result).toEqual(organicResults)
   })
 
-  it('should default to "us" for unknown timezones', async () => {
-    mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
+  it('should default to "America/New_York" when context is missing', async () => {
+    mockSearchWeb.mockResolvedValue([])
 
-    await webSearch.execute(
-      { query: 'news' },
-      { context: { userId: 'u1', timeZone: 'Europe/London' } } as any
-    )
-
-    const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
-    expect(callData.gl).toBe('us')
-  })
-
-  it('should append timezone info to query for time-related searches', async () => {
-    mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
-
-    await webSearch.execute(
-      { query: '¿cuándo es el partido?' },
-      { context: { userId: 'u1', timeZone: 'America/Mexico_City' } } as any
-    )
-
-    const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
-    expect(callData.q).toContain('Mexico City')
-  })
-
-  it('should use "es" as the language for all requests', async () => {
-    mockAxiosRequest.mockResolvedValue({ data: { organic: [] } })
     await webSearch.execute({ query: 'test' })
 
-    const callData = JSON.parse(mockAxiosRequest.mock.calls[0][0].data)
-    expect(callData.hl).toBe('es')
+    expect(mockSearchWeb).toHaveBeenCalledWith('test', 'America/New_York')
+  })
+
+  it('should return error message when searchWeb throws', async () => {
+    mockSearchWeb.mockRejectedValue(new Error('Network error'))
+
+    const result = await webSearch.execute({ query: 'some query' })
+    expect(result).toBe('Hubo un error al buscar la información')
   })
 })

--- a/backEnd/ai-services/src/agents/tools/search.tools.ts
+++ b/backEnd/ai-services/src/agents/tools/search.tools.ts
@@ -1,8 +1,7 @@
 import { RunContext, tool } from '@openai/agents';
 import { z } from 'zod';
-import axios, { AxiosRequestConfig } from 'axios';
-import { serper } from '../../config/index.config';
 import { UserContext } from '../../models/elber.model';
+import { searchWeb } from '../../services/search.service';
 
 export const webSearch = tool({
     name: 'webSearch',
@@ -16,52 +15,8 @@ export const webSearch = tool({
     parameters: z.object({ query: z.string().describe('Consulta del usuario que debe ser buscada en internet')}),
     async execute({ query }, runContext?: RunContext<UserContext>) {
         try {
-            const userContext = runContext?.context
-            const userTimezone = userContext?.timeZone || 'America/New_York'
-            
-            const timezoneToCountry: Record<string, string> = {
-                'America/Mexico_City': 'mx',
-                'America/New_York': 'us',
-            }
-            
-            const countryCode = timezoneToCountry[userTimezone] || 'us'
-            
-            // Detectar si la consulta es sobre eventos/horarios
-            const timeRelatedTerms = ['hora', 'horario', 'cuándo', 'cuando', 'tiempo', 'fecha', 'schedule', 'próximo']
-            const includesTime = timeRelatedTerms.some(term => query.toLowerCase().includes(term))
-            
-            // Preparar query optimizado
-            let searchQuery = query
-            if (includesTime) {
-                searchQuery = `${query} hora local ${userTimezone.split('/')[1]?.replace('_', ' ')}`
-            }
-
-            const searchParams = {
-                "q": searchQuery,
-                "gl": countryCode,
-                "hl": "es"
-            }
-
-            const data = JSON.stringify(searchParams)
-
-            const config: AxiosRequestConfig = {
-                method: 'post',
-                maxBodyLength: Infinity,
-                url: serper.searchURL,
-                headers: {
-                    'X-API-KEY': serper.secret, 
-                    'Content-Type': 'application/json'
-                },
-                data: data
-            }
-
-            const response = await axios.request(config);
-            
-            if (response.data.organic) {
-                return response.data.organic
-            }
-
-            return 'No tengo la información. Sigo aprendiendo'
+            const timeZone = runContext?.context?.timeZone || 'America/New_York'
+            return await searchWeb(query, timeZone)
         } catch (error) {
             console.error(error)
             return 'Hubo un error al buscar la información'

--- a/backEnd/ai-services/src/services/search.service.ts
+++ b/backEnd/ai-services/src/services/search.service.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { serper } from '../config/index.config';
+
+const timezoneToCountry: Record<string, string> = {
+    'America/Mexico_City': 'mx',
+    'America/New_York': 'us',
+}
+
+const timeRelatedTerms = ['hora', 'horario', 'cuándo', 'cuando', 'tiempo', 'fecha', 'schedule', 'próximo']
+
+export const searchWeb = async (query: string, timezone: string): Promise<any> => {
+    const countryCode = timezoneToCountry[timezone] || 'us'
+
+    const includesTime = timeRelatedTerms.some(term => query.toLowerCase().includes(term))
+
+    let searchQuery = query
+    if (includesTime) {
+        searchQuery = `${query} hora local ${timezone.split('/')[1]?.replace('_', ' ')}`
+    }
+
+    const searchParams = {
+        "q": searchQuery,
+        "gl": countryCode,
+        "hl": "es"
+    }
+
+    const config: AxiosRequestConfig = {
+        method: 'post',
+        maxBodyLength: Infinity,
+        url: serper.searchURL,
+        headers: {
+            'X-API-KEY': serper.secret,
+            'Content-Type': 'application/json'
+        },
+        data: JSON.stringify(searchParams)
+    }
+
+    const response = await axios.request(config);
+
+    if (response.data.organic) {
+        return response.data.organic
+    }
+
+    return 'No tengo la información. Sigo aprendiendo'
+}


### PR DESCRIPTION
Extracts `timezoneToCountry` mapping, `timeRelatedTerms` detection, query optimization, and Serper HTTP call from `search.tools.ts` into a dedicated `searchWeb()` function in `search.service.ts`. `search.tools.ts` is now a thin wrapper following the same pattern as `profile.tools.ts` → `profile.service.ts`.

Closes #214

Generated with [Claude Code](https://claude.ai/code)