### PR TITLE
refactor: extract LTM logic from user.tools.ts to user.service.ts

### DIFF
--- a/backEnd/ai-services/src/__tests__/services/user.service.test.ts
+++ b/backEnd/ai-services/src/__tests__/services/user.service.test.ts
@@ -1,7 +1,8 @@
 import admin from 'firebase-admin'
-import { deleteProfile } from '../../services/user.service'
+import { deleteProfile, fetchUserData, deleteAllUserData, deleteUserDataByItems } from '../../services/user.service'
 import ShortTermMemory from '../../models/shortTermMemory.model'
 import MidTermMemory from '../../models/midTermMemory.model'
+import LongTermMemory from '../../models/longTermMemory.model'
 
 jest.mock('firebase-admin', () => ({
   __esModule: true,
@@ -17,6 +18,8 @@ jest.mock('../../models/midTermMemory.model', () => ({
   __esModule: true,
   default: { getInstance: jest.fn() },
 }))
+
+jest.mock('../../models/longTermMemory.model')
 
 jest.mock('../../config/index.config', () => ({
   gateway: { secret: 'test' },
@@ -51,6 +54,10 @@ describe('user.service', () => {
   const mockDeleteUserMemory = jest.fn()
   const mockRemove = jest.fn()
   const mockRef = jest.fn()
+  const mockGetUserData = jest.fn()
+  const mockResetMemory = jest.fn()
+  const mockGetMemory = jest.fn()
+  const mockDeleteMemories = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -60,6 +67,12 @@ describe('user.service', () => {
     ;(MidTermMemory.getInstance as jest.Mock).mockReturnValue({
       deleteUserMemory: mockDeleteUserMemory,
     })
+    ;(LongTermMemory as jest.Mock).mockImplementation(() => ({
+      getUserData: mockGetUserData,
+      resetMemory: mockResetMemory,
+      getMemory: mockGetMemory,
+      deleteMemories: mockDeleteMemories,
+    }))
     mockResetProfileData.mockResolvedValue('He borrado todo tu perfil.')
     mockRemove.mockResolvedValue(undefined)
     mockRef.mockReturnValue({ remove: mockRemove })
@@ -81,6 +94,76 @@ describe('user.service', () => {
       mockResetProfileData.mockRejectedValue(new Error('DB error'))
 
       await expect(deleteProfile('user1')).rejects.toThrow('Unable to delete profile for:user1')
+    })
+  })
+
+  describe('fetchUserData', () => {
+    it('should return up to 10 items from LTM', async () => {
+      const data = Array.from({ length: 15 }, (_, i) => ({
+        type: 'profile',
+        importance: 3,
+        info: `fact ${i}`,
+        updatedAt: '',
+      }))
+      mockGetUserData.mockResolvedValue(data)
+
+      const result = await fetchUserData('user1')
+
+      expect(mockGetUserData).toHaveBeenCalledWith('user1')
+      expect(result).toHaveLength(10)
+    })
+
+    it('should return all items when fewer than 10 exist', async () => {
+      const data = [{ type: 'profile', importance: 3, info: 'fact', updatedAt: '' }]
+      mockGetUserData.mockResolvedValue(data)
+
+      const result = await fetchUserData('user1')
+
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  describe('deleteAllUserData', () => {
+    it('should call resetMemory with the userId', async () => {
+      mockResetMemory.mockResolvedValue(undefined)
+
+      await deleteAllUserData('user1')
+
+      expect(mockResetMemory).toHaveBeenCalledWith('user1')
+    })
+  })
+
+  describe('deleteUserDataByItems', () => {
+    it('should delete found memories and return true', async () => {
+      mockGetMemory.mockResolvedValue([{ id: 'id-1' }, { id: 'id-2' }])
+      mockDeleteMemories.mockResolvedValue(undefined)
+
+      const result = await deleteUserDataByItems('user1', ['where I work'])
+
+      expect(mockGetMemory).toHaveBeenCalledWith('user1', 'where I work')
+      expect(mockDeleteMemories).toHaveBeenCalledWith('user1', ['id-1', 'id-2'])
+      expect(result).toBe(true)
+    })
+
+    it('should accumulate ids across multiple items', async () => {
+      mockGetMemory
+        .mockResolvedValueOnce([{ id: 'id-1' }])
+        .mockResolvedValueOnce([{ id: 'id-2' }, { id: 'id-3' }])
+      mockDeleteMemories.mockResolvedValue(undefined)
+
+      const result = await deleteUserDataByItems('user1', ['job', 'city'])
+
+      expect(mockDeleteMemories).toHaveBeenCalledWith('user1', ['id-1', 'id-2', 'id-3'])
+      expect(result).toBe(true)
+    })
+
+    it('should return false when no memories match', async () => {
+      mockGetMemory.mockResolvedValue([])
+
+      const result = await deleteUserDataByItems('user1', ['nonexistent'])
+
+      expect(mockDeleteMemories).not.toHaveBeenCalled()
+      expect(result).toBe(false)
     })
   })
 })

--- a/backEnd/ai-services/src/__tests__/tools/user.tools.test.ts
+++ b/backEnd/ai-services/src/__tests__/tools/user.tools.test.ts
@@ -8,9 +8,6 @@ import {
 const getUserData = getUserDataTool as any
 const deleteAllUserData = deleteAllUserDataTool as any
 const deleteUserData = deleteUserDataTool as any
-import LongTermMemory from '../../models/longTermMemory.model'
-
-jest.mock('../../models/longTermMemory.model')
 
 jest.mock('@openai/agents', () => ({
   __esModule: true,
@@ -29,20 +26,19 @@ jest.mock('../../services/ltm/vectoreStore.service')
 jest.mock('../../services/ltm/ltmReader.service')
 jest.mock('../../services/ltm/ltmWriter.service')
 
-describe('user.tools', () => {
-  const mockGetUserData = jest.fn()
-  const mockResetMemory = jest.fn()
-  const mockGetMemory = jest.fn()
-  const mockDeleteMemories = jest.fn()
+const mockFetchUserData = jest.fn()
+const mockDeleteAllUserData = jest.fn()
+const mockDeleteUserDataByItems = jest.fn()
 
+jest.mock('../../services/user.service', () => ({
+  fetchUserData: (...args: any[]) => mockFetchUserData(...args),
+  deleteAllUserData: (...args: any[]) => mockDeleteAllUserData(...args),
+  deleteUserDataByItems: (...args: any[]) => mockDeleteUserDataByItems(...args),
+}))
+
+describe('user.tools', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(LongTermMemory as jest.Mock).mockImplementation(() => ({
-      getUserData: mockGetUserData,
-      resetMemory: mockResetMemory,
-      getMemory: mockGetMemory,
-      deleteMemories: mockDeleteMemories,
-    }))
   })
 
   describe('getUserData tool', () => {
@@ -56,25 +52,26 @@ describe('user.tools', () => {
       expect(result).toContain('No pude identificar al usuario')
     })
 
-    it('should return user data sliced to 10 items', async () => {
-      const data = Array.from({ length: 15 }, (_, i) => ({
+    it('should return user data from service', async () => {
+      const data = Array.from({ length: 10 }, (_, i) => ({
         type: 'profile',
         importance: 3,
         info: `fact ${i}`,
         updatedAt: '',
       }))
-      mockGetUserData.mockResolvedValue(data)
+      mockFetchUserData.mockResolvedValue(data)
 
       const result = await getUserData.execute(
         {},
         { context: { userId: 'user1', timeZone: 'UTC' } } as any
       )
 
+      expect(mockFetchUserData).toHaveBeenCalledWith('user1')
       expect(result).toHaveLength(10)
     })
 
     it('should return error message on exception', async () => {
-      mockGetUserData.mockRejectedValue(new Error('DB error'))
+      mockFetchUserData.mockRejectedValue(new Error('DB error'))
       const result = await getUserData.execute(
         {},
         { context: { userId: 'user1', timeZone: 'UTC' } } as any
@@ -89,18 +86,18 @@ describe('user.tools', () => {
       expect(result).toContain('No pude identificar al usuario')
     })
 
-    it('should reset memory and return success message', async () => {
-      mockResetMemory.mockResolvedValue(undefined)
+    it('should call service and return success message', async () => {
+      mockDeleteAllUserData.mockResolvedValue(undefined)
       const result = await deleteAllUserData.execute(
         {},
         { context: { userId: 'user1', timeZone: 'UTC' } } as any
       )
-      expect(mockResetMemory).toHaveBeenCalledWith('user1')
+      expect(mockDeleteAllUserData).toHaveBeenCalledWith('user1')
       expect(result).toBe('He borrado toda la memoria')
     })
 
     it('should return error message on exception', async () => {
-      mockResetMemory.mockRejectedValue(new Error('DB error'))
+      mockDeleteAllUserData.mockRejectedValue(new Error('DB error'))
       const result = await deleteAllUserData.execute(
         {},
         { context: { userId: 'user1', timeZone: 'UTC' } } as any
@@ -126,21 +123,20 @@ describe('user.tools', () => {
       expect(result).toContain('No se especificaron datos')
     })
 
-    it('should delete found memories and return success message', async () => {
-      mockGetMemory.mockResolvedValue([{ id: 'id-1' }, { id: 'id-2' }])
-      mockDeleteMemories.mockResolvedValue(undefined)
+    it('should return success message when service returns true', async () => {
+      mockDeleteUserDataByItems.mockResolvedValue(true)
 
       const result = await deleteUserData.execute(
         { dataToDelete: ['where I work'] },
         { context: { userId: 'user1', timeZone: 'UTC' } } as any
       )
 
-      expect(mockDeleteMemories).toHaveBeenCalledWith('user1', ['id-1', 'id-2'])
+      expect(mockDeleteUserDataByItems).toHaveBeenCalledWith('user1', ['where I work'])
       expect(result).toBe('He borrado los datos')
     })
 
-    it('should return not found message when no memories match', async () => {
-      mockGetMemory.mockResolvedValue([])
+    it('should return not found message when service returns false', async () => {
+      mockDeleteUserDataByItems.mockResolvedValue(false)
 
       const result = await deleteUserData.execute(
         { dataToDelete: ['nonexistent'] },
@@ -151,7 +147,7 @@ describe('user.tools', () => {
     })
 
     it('should return error message on exception', async () => {
-      mockGetMemory.mockRejectedValue(new Error('DB error'))
+      mockDeleteUserDataByItems.mockRejectedValue(new Error('DB error'))
 
       const result = await deleteUserData.execute(
         { dataToDelete: ['job'] },

--- a/backEnd/ai-services/src/agents/tools/user.tools.ts
+++ b/backEnd/ai-services/src/agents/tools/user.tools.ts
@@ -1,7 +1,11 @@
 import { RunContext, tool } from '@openai/agents';
 import { z } from 'zod';
 import { UserContext } from '../../models/elber.model';
-import LongTermMemory from '../../models/longTermMemory.model';
+import {
+    fetchUserData,
+    deleteAllUserData as deleteAllUserDataService,
+    deleteUserDataByItems,
+} from '../../services/user.service';
 
 export const getUserData = tool({
     name: 'get_user_data',
@@ -9,7 +13,7 @@ export const getUserData = tool({
         Obtiene y retorna toda la información personal almacenada del usuario.
         La información se presenta en orden cronológico (más reciente primero).
         En caso de datos duplicados, prevalece la información más reciente.
-        
+
         **Se ejecuta cuando el usuario pregunta:**
         - ¿Qué sabes de mí?
         - ¿Qué información tienes sobre mí?
@@ -24,15 +28,12 @@ export const getUserData = tool({
         if(!userContext?.userId) {
             return "No pude identificar al usuario"
         }
-        
+
         try {
-            const ltm = new LongTermMemory()
-            let data = await ltm.getUserData(userContext.userId)
-            data = data.slice(0,10)
-            return data            
+            return await fetchUserData(userContext.userId)
         } catch (error) {
-            return "Hubo un error al buscar información del usuario."   
-        }        
+            return "Hubo un error al buscar información del usuario."
+        }
     }
 })
 
@@ -41,7 +42,7 @@ export const deleteAllUserData = tool({
     description: `
         Elimina permanentemente toda la información personal almacenada del usuario.
         Esta acción es irreversible y borra completamente la memoria a largo plazo.
-        
+
         **Se ejecuta cuando el usuario solicita:**
         - Olvida todo lo que sabes de mí
         - Borra toda tu memoria sobre mí
@@ -59,12 +60,11 @@ export const deleteAllUserData = tool({
         }
 
         try {
-            const ltm = new LongTermMemory()    
-            await ltm.resetMemory(userContext.userId)
+            await deleteAllUserDataService(userContext.userId)
             return 'He borrado toda la memoria'
         } catch (error) {
             return 'Hubo un error al borrar la memoria'
-        }       
+        }
     }
 })
 
@@ -73,7 +73,7 @@ export const deleteUserData = tool({
     description: `
         Elimina información específica del usuario de la memoria a largo plazo.
         Permite borrar datos particulares sin eliminar todo el perfil del usuario.
-        
+
         **Se ejecuta cuando el usuario solicita:**
         - Olvida dónde trabajo y dónde vivo
         - Borra mi información laboral
@@ -97,21 +97,10 @@ export const deleteUserData = tool({
         }
 
         try {
-            let memoryIds: string[] = []
-            const ltm = new LongTermMemory()    
-            
-            for (let i = 0; i < dataToDelete.length; i++) {
-                const memories = await ltm.getMemory(userContext.userId, dataToDelete[i])
-                const ids = memories.map((memory) => memory.id)
-                memoryIds = [...memoryIds, ...ids]
-            }
-
-            if(memoryIds.length > 0) {
-                await ltm.deleteMemories(userContext.userId, memoryIds)
-                return "He borrado los datos"
-            } else {
-                return "No encontre lo que me has pedido en mi memoria"
-            }            
+            const deleted = await deleteUserDataByItems(userContext.userId, dataToDelete)
+            return deleted
+                ? "He borrado los datos"
+                : "No encontre lo que me has pedido en mi memoria"
         } catch (error) {
             return "Hubo un error al olvidar lo que me has pedido."
         }

--- a/backEnd/ai-services/src/services/user.service.ts
+++ b/backEnd/ai-services/src/services/user.service.ts
@@ -2,6 +2,36 @@ import admin from 'firebase-admin'
 import ShortTermMemory from '../models/shortTermMemory.model'
 import MidTermMemory from '../models/midTermMemory.model'
 import { resetProfileData } from './profile.service'
+import LongTermMemory from '../models/longTermMemory.model'
+import { UserData } from '../models/elber.model'
+
+export const fetchUserData = async (userId: string): Promise<UserData[]> => {
+    const ltm = new LongTermMemory()
+    const data = await ltm.getUserData(userId)
+    return data.slice(0, 10)
+}
+
+export const deleteAllUserData = async (userId: string): Promise<void> => {
+    const ltm = new LongTermMemory()
+    await ltm.resetMemory(userId)
+}
+
+export const deleteUserDataByItems = async (userId: string, dataToDelete: string[]): Promise<boolean> => {
+    const ltm = new LongTermMemory()
+    let memoryIds: string[] = []
+
+    for (const item of dataToDelete) {
+        const memories = await ltm.getMemory(userId, item)
+        memoryIds = [...memoryIds, ...memories.map((m) => m.id)]
+    }
+
+    if (memoryIds.length > 0) {
+        await ltm.deleteMemories(userId, memoryIds)
+        return true
+    }
+
+    return false
+}
 
 export const deleteProfile = async (uid: string) => {
     try {


### PR DESCRIPTION
Follows the profile.service.ts pattern: moves fetchUserData, deleteAllUserData, and deleteUserDataByItems into user.service.ts so tools become thin wrappers. Tests updated to mock at the service layer.

Closes #215

Generated with [Claude Code](https://claude.ai/code)